### PR TITLE
Include message size in log filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ icpx -o allreduce allreduce.cpp -lccl -lmpi -fsycl
 mpirun -n 4 ./allreduce --dtype float --count 1000000 --output ./results
 
 # View results
-cat ./results/oneccl_allreduce_float_results.csv
+cat ./results/oneccl_allreduce_float_1000000_results.csv
 ```
 
 ### Running All Operations

--- a/src/common/include/logger.hpp
+++ b/src/common/include/logger.hpp
@@ -120,8 +120,9 @@ private:
         return result;
     }
     
-    std::string get_filename(const std::string& data_type) const {
-        return output_dir + "/" + library_name + "_" + collective_name + "_" + data_type + "_results.csv";
+    std::string get_filename(const std::string& data_type, size_t message_size_elements) const {
+        return output_dir + "/" + library_name + "_" + collective_name + "_" +
+               data_type + "_" + std::to_string(message_size_elements) + "_results.csv";
     }
     
     void ensure_directory_exists() const {
@@ -219,7 +220,7 @@ public:
             return;
         }
         
-        std::string filename = get_filename(data_type);
+        std::string filename = get_filename(data_type, message_size_elements);
         
         // Sincronizzazione MPI per gestire la scrittura dell'header
         // Solo il rank 0 controlla e scrive l'header se necessario


### PR DESCRIPTION
## Summary
- log results for each message size in separate CSV files
- update README example to reflect new filename scheme